### PR TITLE
Allow return of wrapped functions value.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -48,8 +48,11 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ).catch_unwind().await
                 }.await;
                 <#context_type as test_context::AsyncTestContext>::teardown(ctx).await;
-                if let Err(err) = result {
-                    std::panic::resume_unwind(err);
+                match result {
+                    Ok(returned_value) => returned_value,
+                    Err(err) => {
+                        std::panic::resume_unwind(err);
+                    }
                 }
             }
         }
@@ -59,11 +62,14 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut ctx = <#context_type as test_context::TestContext>::setup();
                 let mut wrapper = std::panic::AssertUnwindSafe(&mut ctx);
                 let result = std::panic::catch_unwind(move || {
-                    #wrapped_name(*wrapper);
+                    #wrapped_name(*wrapper)
                 });
                 <#context_type as test_context::TestContext>::teardown(ctx);
-                if let Err(err) = result {
-                    std::panic::resume_unwind(err);
+                match result {
+                    Ok(returned_value) => returned_value,
+                    Err(err) => {
+                        std::panic::resume_unwind(err);
+                    }
                 }
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,6 +37,16 @@ fn test_panicking_teardown(ctx: &mut Context) {
     panic!("First panic");
 }
 
+#[test_context(Context)]
+fn return_value_func(ctx: &mut Context) -> u32 {
+    ctx.n
+}
+
+#[test]
+fn includes_return_value() {
+    assert_eq!(return_value_func(), 1);
+}
+
 struct AsyncContext {
     n: u32,
 }
@@ -73,4 +83,14 @@ async fn test_async_teardown(ctx: &mut AsyncContext) {
 async fn test_async_panicking_teardown(ctx: &mut AsyncContext) {
     ctx.n = 2;
     panic!("First panic");
+}
+
+#[test_context(AsyncContext)]
+async fn async_return_value_func(ctx: &mut AsyncContext) -> u32 {
+    ctx.n
+}
+
+#[tokio::test]
+async fn async_includes_return_value() {
+    assert_eq!(async_return_value_func().await, 1);
 }


### PR DESCRIPTION
This allows the macro to return the value of the function being
annotated. For most testing, this probably shouldn't matter, but
considering it's simple enough to do I decided to add it in in case any
other test wrappers require it.