### PR TITLE
Forced futures to be imported through test_context crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["development-tools::testing"]
 [dependencies]
 test-context-macros = { version = "0.1.1", path = "macros" }
 async-trait = "0.1.42"
+futures = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"]}
-futures = "0.3.12"
 
 [workspace]
 members = [

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -39,7 +39,7 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
     let outer_body = if is_async {
         quote! {
             {
-                use futures::FutureExt;
+                use test_context::futures::FutureExt;
                 let mut ctx = <#context_type as test_context::AsyncTestContext>::setup().await;
                 let wrapped_ctx = &mut ctx;
                 let result = async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@
 //! }
 //! ```
 
+// Reimported to allow for use in the macro.
+pub use futures;
+
 pub use test_context_macros::test_context;
 
 /// The trait to implement to get setup/teardown functionality for tests.


### PR DESCRIPTION
By exporting the futures crate through the test_context crate, the code
generated by the macro can rely on `test_context` to access the future
crate. Otherwise, the code generated which requires access to the
"future" crate would end up residing in the code of a user of the
library, giving them `use of undeclared crate or module "future"`
error messages unless they added future as a dependency.