### PR TITLE
add basic impl TestContext for AsyncTestContext

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,3 +84,18 @@ where
     /// normal "drop" semantics.
     async fn teardown(self) {}
 }
+
+// Automatically impl TestContext for anything Send that impls AsyncTestContext.
+//
+// A future improvement may be to use feature flags to enable using a specific runtime
+// to run the future synchronously. This is the easiest way to implement it, though, and
+// introduces no new dependencies.
+impl<T> TestContext for T where T: AsyncTestContext + Send {
+    fn setup() -> Self {
+        futures::executor::block_on(<T as AsyncTestContext>::setup())
+    }
+
+    fn teardown(self) {
+        futures::executor::block_on(<T as AsyncTestContext>::teardown(self))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,10 @@ where
 // A future improvement may be to use feature flags to enable using a specific runtime
 // to run the future synchronously. This is the easiest way to implement it, though, and
 // introduces no new dependencies.
-impl<T> TestContext for T where T: AsyncTestContext + Send {
+impl<T> TestContext for T
+where
+    T: AsyncTestContext + Send,
+{
     fn setup() -> Self {
         futures::executor::block_on(<T as AsyncTestContext>::setup())
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -94,3 +94,9 @@ async fn async_return_value_func(ctx: &mut AsyncContext) -> u32 {
 async fn async_includes_return_value() {
     assert_eq!(async_return_value_func().await, 1);
 }
+
+#[test_context(AsyncContext)]
+#[test]
+fn async_auto_impls_sync(ctx: &mut AsyncContext) {
+    assert_eq!(ctx.n, 1);
+}


### PR DESCRIPTION
Initial, simple implementation for #8.

See linked issue for discussion on how this could be improved further -- I think the attribute macros would be the way to go, and I am willing and able to implement them if that is what @markhildreth thinks is best.