### PR TITLE
Mutable context for teardowns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test-context"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 description = "A library for providing custom setup/teardown for Rust tests without needing a test harness"
 homepage = "https://github.com/markhildreth/test-context"
 repository = "https://github.com/markhildreth/test-context"
 readme = "README.md"
-authors = ["Mark Hildreth <mark.k.hildreth@gmail.com>"]
+authors = ["Mark Hildreth <mark.k.hildreth@gmail.com>", "Ahmed Masud <ahmed.masud@saf.ai>"]
 license = "MIT"
 categories = ["development-tools::testing"]
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -47,7 +47,7 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
                         #wrapped_name(wrapped_ctx)
                     ).catch_unwind().await
                 }.await;
-                <#context_type as test_context::AsyncTestContext>::teardown(ctx).await;
+                <#context_type as test_context::AsyncTestContext>::teardown(&mut ctx).await;
                 match result {
                     Ok(returned_value) => returned_value,
                     Err(err) => {
@@ -64,7 +64,7 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let result = std::panic::catch_unwind(move || {
                     #wrapped_name(*wrapper)
                 });
-                <#context_type as test_context::TestContext>::teardown(ctx);
+                <#context_type as test_context::TestContext>::teardown(&mut ctx);
                 match result {
                     Ok(returned_value) => returned_value,
                     Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!         MyContext {  value: "Hello, world!".to_string() }
 //!     }
 //!
-//!     fn teardown(self) {
+//!     fn teardown(&mut self) {
 //!         // Perform any teardown you wish.
 //!     }
 //! }
@@ -40,7 +40,7 @@
 //!         MyAsyncContext { value: "Hello, world!".to_string() }
 //!     }
 //!
-//!     async fn teardown(self) {
+//!     async fn teardown(&mut self) {
 //!         // Perform any teardown you wish.
 //!     }
 //! }
@@ -65,7 +65,7 @@
 //! #     async fn setup() -> MyAsyncContext {
 //! #         MyAsyncContext { value: "Hello, world!".to_string() }
 //! #     }
-//! #     async fn teardown(self) {
+//! #     async fn teardown(&mut self) {
 //! #         // Perform any teardown you wish.
 //! #     }
 //! # }
@@ -91,7 +91,7 @@ where
 
     /// Perform any additional cleanup of the context besides that already provided by
     /// normal "drop" semantics.
-    fn teardown(self) {}
+    fn teardown(&mut self) {}
 }
 
 /// The trait to implement to get setup/teardown functionality for async tests.
@@ -105,7 +105,7 @@ where
 
     /// Perform any additional cleanup of the context besides that already provided by
     /// normal "drop" semantics.
-    async fn teardown(self) {}
+    async fn teardown(&mut self) {}
 }
 
 // Automatically impl TestContext for anything Send that impls AsyncTestContext.
@@ -121,7 +121,7 @@ where
         futures::executor::block_on(<T as AsyncTestContext>::setup())
     }
 
-    fn teardown(self) {
+    fn teardown(&mut self) {
         futures::executor::block_on(<T as AsyncTestContext>::teardown(self))
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@ impl TestContext for Context {
         Self { n: 1 }
     }
 
-    fn teardown(self) {
+    fn teardown(&mut self) {
         if self.n != 1 {
             panic!("Number changed");
         }
@@ -57,7 +57,7 @@ impl AsyncTestContext for AsyncContext {
         Self { n: 1 }
     }
 
-    async fn teardown(self) {
+    async fn teardown(&mut self) {
         if self.n != 1 {
             panic!("Number changed");
         }


### PR DESCRIPTION
Passing a mutable reference to `self` as parameter to teardown.  Necessary for deeper cleanups. 
