### PR TITLE
Copy original argument list directly from input token stream.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -30,6 +30,7 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let ret = &input.sig.output;
     let name = &input.sig.ident;
+    let arguments = &input.sig.inputs;
     let inner_body = &input.block;
     let attrs = &input.attrs;
     let is_async = input.sig.asyncness.is_some();
@@ -85,7 +86,7 @@ pub fn test_context(attr: TokenStream, item: TokenStream) -> TokenStream {
         #(#attrs)*
         #async_tag fn #name() #ret #outer_body
 
-        #async_tag fn #wrapped_name(ctx: &mut #context_type) #ret #inner_body
+        #async_tag fn #wrapped_name(#arguments) #ret #inner_body
     };
     result.into()
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,7 +25,7 @@ fn test_sync_setup(ctx: &mut Context) {
 #[test_context(Context)]
 #[test]
 #[should_panic(expected = "Number changed")]
-fn test_sync_teardown(ctx: &mut Wrapper) {
+fn test_sync_teardown(ctx: &mut Context) {
     ctx.n = 2;
 }
 
@@ -99,4 +99,16 @@ async fn async_includes_return_value() {
 #[test]
 fn async_auto_impls_sync(ctx: &mut AsyncContext) {
     assert_eq!(ctx.n, 1);
+}
+
+#[test_context(Context)]
+#[test]
+fn use_different_name(test_data: &mut Context) {
+    assert_eq!(test_data.n, 1);
+}
+
+#[test_context(AsyncContext)]
+#[tokio::test]
+async fn use_different_name_async(test_data: &mut AsyncContext) {
+    assert_eq!(test_data.n, 1);
 }


### PR DESCRIPTION
The prior version would hard-code the argument for the wrapped function
with an argument "ctx" and the type used for the context. As pointed out
in issue 14 (https://github.com/markhildreth/test-context/issues/14), this means that the argument name for the context is hard-coded to
"ctx".

Note that this is a breaking change. For example, the following code
might have compiled prior, but now would raise an error:

```
fn test(ctx: &mut IncorrectName) {...}
```

Since "IncorrectName" is now actually going to be used in the wrapper
function argument list, a different error (most likely "cannot find type
in this scope") will be given instead.

As this library is using the major zero version, I'm okay making this
breaking change.