### PR TITLE
Use proper World capitalization in the main example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ struct MyContext {
 
 impl TestContext for MyContext {
     fn setup() -> MyContext {
-        MyContext {  value: "Hello, world!".to_string() }
+        MyContext {  value: "Hello, World!".to_string() }
     }
 
     fn teardown(self) {
@@ -27,7 +27,7 @@ impl TestContext for MyContext {
 #[test_context(MyContext)]
 #[test]
 fn test_works(ctx: &mut MyContext) {
-    assert_eq!(ctx.value, "Hello, world!");
+    assert_eq!(ctx.value, "Hello, World!");
 }
 ```
 
@@ -44,7 +44,7 @@ struct MyAsyncContext {
 #[async_trait::async_trait]
 impl AsyncTestContext for MyAsyncContext {
     async fn setup() -> MyAsyncContext {
-        MyAsyncContext { value: "Hello, world!".to_string() }
+        MyAsyncContext { value: "Hello, World!".to_string() }
     }
 
     async fn teardown(self) {


### PR DESCRIPTION
In the README.md, at least this assertion

https://github.com/markhildreth/test-context/blame/main/README.md#L57

fails, so seems easier to capitalize every other "world" occurrence to ensure all examples are correct.