### PR TITLE
[chore] Get rid of async_trait due to formalisation of async traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,10 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 test-context-macros = { version = "0.1.4", path = "macros" }
-async-trait = "0.1.42"
 futures = "0.3"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["macros", "rt"]}
+tokio = { version = "1.0", features = ["macros", "rt"] }
 
 [workspace]
-members = [
-  "macros",
-]
+members = ["macros"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,17 +95,18 @@ where
 }
 
 /// The trait to implement to get setup/teardown functionality for async tests.
-#[async_trait::async_trait]
 pub trait AsyncTestContext
 where
     Self: Sized,
 {
     /// Create the context. This is run once before each test that uses the context.
-    async fn setup() -> Self;
+    fn setup() -> impl std::future::Future<Output = Self> + Send;
 
     /// Perform any additional cleanup of the context besides that already provided by
     /// normal "drop" semantics.
-    async fn teardown(self) {}
+    fn teardown(self) -> impl std::future::Future<Output = ()> + Send {
+        async {}
+    }
 }
 
 // Automatically impl TestContext for anything Send that impls AsyncTestContext.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -51,7 +51,6 @@ struct AsyncContext {
     n: u32,
 }
 
-#[async_trait::async_trait]
 impl AsyncTestContext for AsyncContext {
     async fn setup() -> Self {
         Self { n: 1 }


### PR DESCRIPTION
Async traits were stabilized on the [1.75 release](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html) of Rust

Therefore `async_trait` is no longer needed unless someone wants to use the traits as Trait objects (Which I don't think someone should do using this library)